### PR TITLE
mini-fix ModuleRootNode.toString()

### DIFF
--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/nodes/ModuleRootNode.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/nodes/ModuleRootNode.java
@@ -58,7 +58,7 @@ public class ModuleRootNode extends PClosureRootNode {
     @Override
     public String toString() {
         CompilerAsserts.neverPartOfCompilation();
-        return "<module '" + name + "'>";
+        return name;
     }
 
     @Override


### PR DESCRIPTION
`this.name` is already wrapped in `this.name = "<module '" + name + "'>";` in constructor