### PR TITLE
Add specialization for SetItemScalarNode

### DIFF
--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/common/SequenceStorageNodes.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/common/SequenceStorageNodes.java
@@ -847,6 +847,11 @@ public abstract class SequenceStorageNodes {
             storage.setLongItemNormalized(idx, value);
         }
 
+        @Specialization
+        protected void doLong(LongSequenceStorage storage, int idx, int value) {
+            storage.setLongItemNormalized(idx, value); 
+        }
+
         @Specialization(guards = "!value.isNative()")
         protected void doLong(LongSequenceStorage storage, int idx, PInt value) {
             try {


### PR DESCRIPTION
Bug fix when setting an Integer to an item of a Long list.

Example:

```py
x = [2147483648, 1]
x[0] = 42 # throw java.lang.IllegalStateException
from array import array
y = array('l', [1, 2])
y[0] = 42 # throw java.lang.IllegalStateException
```

Exception:

```
java.lang.IllegalStateException
	at com.oracle.graal.python.builtins.objects.common.SequenceStorageNodes$SetItemNode.doScalarInt(SequenceStorageNodes.java:706)
	at com.oracle.graal.python.builtins.objects.common.SequenceStorageNodesFactory$SetItemNodeGen.executeAndSpecialize(SequenceStorageNodesFactory.java:887)
	at com.oracle.graal.python.builtins.objects.common.SequenceStorageNodesFactory$SetItemNodeGen.execute(SequenceStorageNodesFactory.java:839)
	at com.oracle.graal.python.builtins.objects.list.ListBuiltins$SetItemNode.doGeneric(ListBuiltins.java:255)
	at com.oracle.graal.python.builtins.objects.list.ListBuiltinsFactory$SetItemNodeFactory$SetItemNodeGen.executeAndSpecialize(ListBuiltinsFactory.java:707)
	at com.oracle.graal.python.builtins.objects.list.ListBuiltinsFactory$SetItemNodeFactory$SetItemNodeGen.execute(ListBuiltinsFactory.java:691)
	at com.oracle.graal.python.nodes.call.special.CallTernaryMethodNode.call(CallTernaryMethodNode.java:65)
	at com.oracle.graal.python.nodes.call.special.CallTernaryMethodNodeGen.executeAndSpecialize(CallTernaryMethodNodeGen.java:317)
	at com.oracle.graal.python.nodes.call.special.CallTernaryMethodNodeGen.execute(CallTernaryMethodNodeGen.java:276)
	at com.oracle.graal.python.nodes.subscript.SetItemNode.doSpecialObject(SetItemNode.java:114)
	at com.oracle.graal.python.nodes.subscript.SetItemNodeGen.executeAndSpecialize(SetItemNodeGen.java:337)
	at com.oracle.graal.python.nodes.subscript.SetItemNodeGen.executeVoid_generic3(SetItemNodeGen.java:315)
	at com.oracle.graal.python.nodes.subscript.SetItemNodeGen.executeVoid(SetItemNodeGen.java:260)
	at com.oracle.graal.python.nodes.expression.ExpressionNode$ExpressionWithSideEffects.execute(ExpressionNode.java:151)
	at com.oracle.graal.python.nodes.frame.WriteLocalVariableNodeGen.executeVoid_generic4(WriteLocalVariableNodeGen.java:120)
	at com.oracle.graal.python.nodes.frame.WriteLocalVariableNodeGen.executeVoid(WriteLocalVariableNodeGen.java:53)
	at com.oracle.graal.python.nodes.expression.ExpressionNode$ExpressionWithSideEffects.execute(ExpressionNode.java:151)
	at com.oracle.graal.python.nodes.ModuleRootNode.execute(ModuleRootNode.java:51)
	at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callProxy(OptimizedCallTarget.java:289)
	at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callRoot(OptimizedCallTarget.java:278)
	at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callBoundary(OptimizedCallTarget.java:265)
	at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.doInvoke(OptimizedCallTarget.java:247)
	at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.call(OptimizedCallTarget.java:223)
	at com.oracle.graal.python.nodes.control.TopLevelExceptionHandler.run(TopLevelExceptionHandler.java:216)
	at com.oracle.graal.python.nodes.control.TopLevelExceptionHandler.execute(TopLevelExceptionHandler.java:111)
	at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callProxy(OptimizedCallTarget.java:289)
	at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callRoot(OptimizedCallTarget.java:278)
	at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callBoundary(OptimizedCallTarget.java:265)
	at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.doInvoke(OptimizedCallTarget.java:247)
	at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.call(OptimizedCallTarget.java:223)
	at com.oracle.truffle.polyglot.PolyglotContextImpl.eval(PolyglotContextImpl.java:714)
	at org.graalvm.polyglot.Context.eval(Context.java:331)
	at com.oracle.graal.python.shell.GraalPythonMain.readEvalPrint(GraalPythonMain.java:542)
	at com.oracle.graal.python.shell.GraalPythonMain.launch(GraalPythonMain.java:204)
	at org.graalvm.launcher.AbstractLanguageLauncher.launch(AbstractLanguageLauncher.java:122)
	at org.graalvm.launcher.AbstractLanguageLauncher.launch(AbstractLanguageLauncher.java:70)
	at com.oracle.graal.python.shell.GraalPythonMain.main(GraalPythonMain.java:57)
Caused by: Attached Guest Language Frames (2)
java.lang.IllegalStateException

```