### PR TITLE
Don't print TruffleObjects on AttributeError

### DIFF
--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/foreign/TruffleObjectBuiltins.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/foreign/TruffleObjectBuiltins.java
@@ -642,7 +642,7 @@ public class TruffleObjectBuiltins extends PythonBuiltins {
                 }
             } catch (UnknownIdentifierException | UnsupportedMessageException ignore) {
             }
-            throw raise(PythonErrorType.AttributeError, "foreign object %s has no attribute %s", object, key);
+            throw raise(PythonErrorType.AttributeError, "foreign object has no attribute %s", key);
         }
     }
 
@@ -655,7 +655,7 @@ public class TruffleObjectBuiltins extends PythonBuiltins {
             try {
                 lib.writeMember(object, key, value);
             } catch (UnknownIdentifierException | UnsupportedMessageException | UnsupportedTypeException e) {
-                throw raise(PythonErrorType.AttributeError, "foreign object %s has no attribute %s", object, key);
+                throw raise(PythonErrorType.AttributeError, "foreign object has no attribute %s", key);
             }
             return PNone.NONE;
         }
@@ -682,7 +682,7 @@ public class TruffleObjectBuiltins extends PythonBuiltins {
             try {
                 lib.removeMember(object, key);
             } catch (UnknownIdentifierException | UnsupportedMessageException e) {
-                throw raise(PythonErrorType.AttributeError, "foreign object %s has no attribute %s", object, key);
+                throw raise(PythonErrorType.AttributeError, "foreign object has no attribute %s", key);
             }
             return PNone.NONE;
         }


### PR DESCRIPTION
This avoids that internal implementation details leak when an `AttributeError` is raised on TruffleObjects.

See https://github.com/graalvm/graaljs/issues/84#issuecomment-482147889