### PR TITLE
Add boxed specializations of BytesBuiltin.FindNode

### DIFF
--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/bytes/BytesBuiltins.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/bytes/BytesBuiltins.java
@@ -492,7 +492,17 @@ public class BytesBuiltins extends PythonBuiltins {
         }
 
         @Specialization
+        int find (VirtualFrame frame, PBytes self, Object sub, Number start, @SuppressWarnings("unused") PNone end) {
+            return find(frame, self, sub, start, getLength(self.getSequenceStorage()));
+        }
+
+        @Specialization
         int find(VirtualFrame frame, PBytes self, Object sub, int start, int ending) {
+            return getFindNode().execute(frame, self, sub, start, ending);
+        }
+
+        @Specialization
+        int find(VirtualFrame frame, PBytes self, Object sub, Number start, Number ending) {
             return getFindNode().execute(frame, self, sub, start, ending);
         }
 


### PR DESCRIPTION
Prior to this commit, pytz.timezone fails with an
UnsupportedSpecializationException because it calls bytes.find with a
(boxed) Long rather than an int for the argument `start`. To fix this,
I've added new specializations that expect a Number, which should allow
this method to work when passed in boxed number types.

I've tested an equivalent change based on 19.3.0 but have had trouble
testing against master. If someone could help me with that I would
greatly appreciate it.