### PR TITLE
Pass through cls when constructing no-argument set

### DIFF
--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/set/SetNodes.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/set/SetNodes.java
@@ -93,7 +93,7 @@ public abstract class SetNodes {
         @SuppressWarnings("unused")
         PSet set(LazyPythonClass cls, PNone none,
                         @Shared("factory") @Cached PythonObjectFactory factory) {
-            return factory.createSet();
+            return factory.createSet(cls);
         }
 
         @Specialization(guards = "!isNoValue(iterable)")


### PR DESCRIPTION
Adds cls as an argument to factory.createSet in the no-argument
specialization of the set constructor. Without this, attempts to
instantiate a subclass of set with no arguments will instead create a
regular set.