### PR TITLE
Note that parse with argument names is not supported

### DIFF
--- a/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/PythonLanguage.java
+++ b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/PythonLanguage.java
@@ -240,6 +240,7 @@ public final class PythonLanguage extends TruffleLanguage<PythonContext> {
 
     @Override
     protected CallTarget parse(ParsingRequest request) {
+        assert request.getArgumentNames().isEmpty() : "argument names not yet supported";
         PythonContext context = getCurrentContext(PythonLanguage.class);
         PythonCore core = context.getCore();
         Source source = request.getSource();


### PR DESCRIPTION
As far as I can tell, GraalPython doesn’t support parse requests with argument names yet; I think throwing an assertion error with a clear message in that case is nicer than raising a NameError later.