### PR TITLE
Fix ginstall uninstall command when executing the command on a virtual environment

### DIFF
--- a/graalpython/lib-graalpython/modules/ginstall.py
+++ b/graalpython/lib-graalpython/modules/ginstall.py
@@ -555,7 +555,13 @@ def main(argv):
                 info(p[len(user_site) + 1:])
     elif args.command == "uninstall":
         warn("WARNING: I will only delete the package folder, proper uninstallation is not supported at this time.")
-        user_site = site.getusersitepackages()
+        if site.ENABLE_USER_SITE:
+            user_site = site.getusersitepackages()
+        else:
+            for s in site.getsitepackages():
+                if s.endswith("site-packages"):
+                    user_site = s
+                    break
         for pkg in args.package.split(","):
             deleted = False
             for p in sys.path:

--- a/graalpython/lib-graalpython/modules/ginstall.py
+++ b/graalpython/lib-graalpython/modules/ginstall.py
@@ -497,6 +497,14 @@ def install_from_pypi(package, extra_opts=[], add_cflags="", ignore_errors=True,
     else:
         xit("Package not found: '%s'" % package)
 
+def get_site_packages_path():
+    if site.ENABLE_USER_SITE:
+        return site.getusersitepackages()
+    else:
+        for s in site.getsitepackages():
+            if s.endswith("site-packages"):
+                return s
+    return None
 
 def main(argv):
     parser = argparse.ArgumentParser(description="The simple Python package installer for GraalVM")
@@ -542,26 +550,14 @@ def main(argv):
     args = parser.parse_args(argv)
 
     if args.command == "list":
-        if site.ENABLE_USER_SITE:
-            user_site = site.getusersitepackages()
-        else:
-            for s in site.getsitepackages():
-                if s.endswith("site-packages"):
-                    user_site = s
-                    break
+        user_site = get_site_packages_path()
         info("Installed packages:")
         for p in sys.path:
             if p.startswith(user_site):
                 info(p[len(user_site) + 1:])
     elif args.command == "uninstall":
         warn("WARNING: I will only delete the package folder, proper uninstallation is not supported at this time.")
-        if site.ENABLE_USER_SITE:
-            user_site = site.getusersitepackages()
-        else:
-            for s in site.getsitepackages():
-                if s.endswith("site-packages"):
-                    user_site = s
-                    break
+        user_site = get_site_packages_path()
         for pkg in args.package.split(","):
             deleted = False
             for p in sys.path:


### PR DESCRIPTION
# Problem
I wasn't able to uninstall libraries via ginstall when I was on a virtual enviroment.

```
$ source my_new_venv/bin/activate
(my_new_venv) $ graalpython -m ginstall list                                                                                                 
Installed packages:                                                                                                                                                                     
                                                                                                                                                                                        
pytz-2018.7-py3.8.egg                                                                                                                                                                   
setuptools_scm-1.15.0-py3.8.egg                                                                                                                                                         
python_dateutil-2.7.5-py3.8.egg                                                                                                                                                         
numpy-1.16.4-py3.8-macosx-10.14-x86_64.egg
(my_new_venv) $ graalpython -m ginstall uninstall numpy                                                                                      
Please note: This Python implementation is in the very early stages, and can run little more than basic benchmarks at this point.                                                       
WARNING: I will only delete the package folder, proper uninstallation is not supported at this time.                                                                                    
Unknown package: 'numpy'
```

## Environment
* GraalVM CE 20.1.0 Java 11
* Python 3.8.2 (GraalVM CE Native 20.1.0)
* macOS 10.15

# Factor
This is because the uninstall process checks the `~/.local/lib/python3.8/site-packages` directory when on a virtual environment. I think it should check the `[virtualenv]/lib/python3.8/site-packages` directory in that case.

# Changed Contents
So I changed the code to be the same as `ginstall list`.

# Test

```
(my_new_venv) $ graalpython -m ginstall uninstall numpy                                                             
Please note: This Python implementation is in the very early stages, and can run little more than basic benchmarks at this point.                                                       
WARNING: I will only delete the package folder, proper uninstallation is not supported at this time.                                                                                    
Deleted /Users/jyukutyo/my_new_venv/lib/python3.8/site-packages/numpy-1.16.4-py3.8-macosx-10.14-x86_64.egg
```

Of course this PR works when not on a virtual environment.

```
$ graalpython -m ginstall list
Installed packages:

setuptools-41.0.1-py3.8.egg
setuptools_scm-1.15.0-py3.8.egg
python_dateutil-2.7.5-py3.8.egg
$ graalpython -m ginstall uninstall python_dateutil
Please note: This Python implementation is in the very early stages, and can run little more than basic benchmarks at this point.
WARNING: I will only delete the package folder, proper uninstallation is not supported at this time.
Deleted /Users/jyukutyo/.local/lib/python3.8/site-packages/python_dateutil-2.7.5-py3.8.egg
```